### PR TITLE
Earthexp

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,8 +3,8 @@ Type: Package
 Title: Satellite Remote Sensing (Earth Observation) data analysis
 Version: 0.2-2
 Date: 2019-07-23
-Imports: terra
-Depends: httr, readr, xml2
+Depends: R (>= 3.5.0)
+Imports: terra, httr, readr, xml2, jsonlite
 SystemRequirements: C++11
 Author: Aniruddha Ghosh, Alex Mandel, Benson Kenduiywo, Robert Hijmans 
 Maintainer: <r.hijmans@gmail.com>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Title: Satellite Remote Sensing (Earth Observation) data analysis
 Version: 0.2-2
 Date: 2019-07-23
 Imports: terra
-Depends: httr, readr
+Depends: httr, readr, xml2
 SystemRequirements: C++11
 Author: Aniruddha Ghosh, Alex Mandel, Benson Kenduiywo, Robert Hijmans 
 Maintainer: <r.hijmans@gmail.com>

--- a/R/cmr_funs.R
+++ b/R/cmr_funs.R
@@ -152,7 +152,7 @@ productInfo <- function(product, ...){
 #   invisible(readline(prompt="Press [enter] to open the webpage of the next product or "))
 # }
 
-simplify_urls <- function(response_table, sat){
+simplify_urls <- function(response_table, server, ...){
   # Depending on the type of data requested the url formatting will vary
   # MODIS the download url is the `Online Access URLs`
   # Landsat the `Online Access URLs` is a webpage listing options
@@ -160,17 +160,21 @@ simplify_urls <- function(response_table, sat){
   #  2. We can construct the AWS or Google URL to the same thing
   #   a. AWS and Google might be per band files instead of a single archive (tar.gz)
   
-  if (sat == "MODIS"){
+  if (server == "MODIS"){
     # TODO: Handle errors from the TryCatch
     catcher <- tryCatch(urls <- response_table$`Online Access URLs`,error=function(e){e})
     urls <- catcher
-  } else if (sat == "L8"){
+  } else if (server == "AWS"){
     # TODO: Handle errors from the TryCatch
     #"https://landsatonaws.com/L8/025/023/LC08_L1TP_025023_20190717_20190717_01_RT/"
     catcher <- tryCatch(urls <- response_table$`Granule UR`,error=function(e){e})
     sceneID <- catcher[grep("T1$", catcher)]
     urls <- unlist(lapply(sceneID, .find_aws))
-  } else {
+  } else if (server == "ERS"){
+    sceneID <- tryCatch(urls <- response_table$`Online Access URLs`,error=function(e){e})
+    urls <- unlist(lapply(sceneID, find_durls_ers))
+  } 
+  else {
     # TODO: What to do if no urls are found?
     urls <- NULL
   }

--- a/R/cmr_funs.R
+++ b/R/cmr_funs.R
@@ -140,7 +140,7 @@ productInfo <- function(product, ...){
   
 	if (length(url) > 0 ){
 		print(paste0("opening product description web page for ", unique(pp$short_name[1])))
-		browseURL(url)	  
+		utils::browseURL(url)	  
 	}
 }
 

--- a/R/ee.R
+++ b/R/ee.R
@@ -6,10 +6,10 @@ library(httr)
 library(jsonlite)
 
 URL <- "https://earthexplorer.usgs.gov/inventory/json/v/1.4.0"
-LOGIN_URL <- file.path(url, "login")
-LOGOUT_URL <- file.path(url, "logout")
-SEARCH_URL <- file.path(url, "search")
-DOWNLOADOPT_URL <- file.path(url, "downloadoptions")
+LOGIN_URL <- file.path(URL, "login")
+LOGOUT_URL <- file.path(URL, "logout")
+SEARCH_URL <- file.path(URL, "search")
+DOWNLOADOPT_URL <- file.path(URL, "downloadoptions")
 
 .make_params <- function(params){
   # EE API requires a very specific format for parameters to the api, 
@@ -25,7 +25,7 @@ DOWNLOADOPT_URL <- file.path(url, "downloadoptions")
     password = PASSWORD,
     catalogId = "EE"
   )
-  auth <- httr::POST(login_url, body=.make_params(params), content_type("application/x-www-form-urlencoded"))
+  auth <- httr::POST(LOGIN_URL, body=.make_params(params), content_type("application/x-www-form-urlencoded"))
   
   #TODO: Check the http status
   token <- content(auth)$data  
@@ -39,7 +39,7 @@ DOWNLOADOPT_URL <- file.path(url, "downloadoptions")
     apiKey=token
   )
   
-  logout <- httr::GET(logout_url, query=.make_params(params))
+  logout <- httr::GET(LOGOUT_URL, query=.make_params(params))
   #TODO: Check the http status
   # TODO: If error api_version is 1.3.0, if works 1.4.0
 }
@@ -52,7 +52,7 @@ DOWNLOADOPT_URL <- file.path(url, "downloadoptions")
     apiKey = token
   )
   
-  durl <- httr::GET(downloadopt_url, query=.make_params(params)) #Does this work?
+  durl <- httr::GET(DOWNLOADOPT_URL, query=.make_params(params)) #Does this work?
   #durl_post <- httr::POST(downloadopt_url, body=json_params, content_type("application/x-www-form-urlencoded"), verbose(info=TRUE, ssl=TRUE))
   
   #TODO return the url to the file
@@ -97,7 +97,7 @@ DOWNLOADOPT_URL <- file.path(url, "downloadoptions")
   )
   
   # GET works now that the query is used to send params
-  sdata <- httr::GET(search_url,
+  sdata <- httr::GET(SEARCH_URL,
                      #verbose(info=TRUE),
                      query=.make_params(params)
   )

--- a/R/ee.R
+++ b/R/ee.R
@@ -4,20 +4,16 @@
 # Documnentation of API (requires login)
 # https://earthexplorer.usgs.gov/inventory/documentation/json-api
 
-library(httr)
-library(jsonlite)
-#library(sf)
-
-URL <- "https://earthexplorer.usgs.gov/inventory/json/v/1.4.0"
-LOGIN_URL <- file.path(URL, "login")
-LOGOUT_URL <- file.path(URL, "logout")
-SEARCH_URL <- file.path(URL, "search")
-DOWNLOADOPT_URL <- file.path(URL, "downloadoptions")
+.EE_API_URL <- "https://earthexplorer.usgs.gov/inventory/json/v/1.4.0"
+.EE_API_LOGIN_URL <- file.path(.EE_API_URL, "login")
+.EE_API_LOGOUT_URL <- file.path(.EE_API_URL, "logout")
+.EE_API_SEARCH_URL <- file.path(.EE_API_URL, "search")
+.EE_API_DOWNLOADOPT_URL <- file.path(.EE_API_URL, "downloadoptions")
 
 .make_params <- function(params){
   # EE API requires a very specific format for parameters to the api, 
   # json inside a query object or body
-  json_params <- paste("jsonRequest=",toJSON(params, auto_unbox = TRUE),sep="")
+  json_params <- paste("jsonRequest=",jsonlite::toJSON(params, auto_unbox = TRUE),sep="")
   return(json_params)
 }
 
@@ -28,14 +24,14 @@ DOWNLOADOPT_URL <- file.path(URL, "downloadoptions")
     password = PASSWORD,
     catalogId = "EE"
   )
-  auth <- httr::POST(LOGIN_URL, body=.make_params(params), content_type("application/x-www-form-urlencoded"))
+  auth <- httr::POST(.EE_API_LOGIN_URL, body=.make_params(params), httr::content_type("application/x-www-form-urlencoded"))
   
   #TODO: Check the http status
   # If you ar approved 
   auth_data <- .is_json(auth)
   if (!(auth_data$access_level == "approved")){
       print("You need API access approval, opening website to request")
-      browseURL("https://ers.cr.usgs.gov/profile/access")
+      utils::browseURL("https://ers.cr.usgs.gov/profile/access")
       # TODO: return error and exit
       # Other possible checks, api version is 1.3.0, access_level is guest
   }
@@ -50,7 +46,7 @@ DOWNLOADOPT_URL <- file.path(URL, "downloadoptions")
     apiKey=token
   )
   
-  logout <- httr::GET(LOGOUT_URL, query=.make_params(params))
+  logout <- httr::GET(.EE_API_LOGOUT_URL, query=.make_params(params))
   #TODO: Check the http status
   # TODO: If error api_version is 1.3.0, if works 1.4.0
 }
@@ -63,7 +59,7 @@ DOWNLOADOPT_URL <- file.path(URL, "downloadoptions")
     apiKey = token
   )
   
-  durl <- httr::GET(DOWNLOADOPT_URL, query=.make_params(params))
+  durl <- httr::GET(.EE_API_DOWNLOADOPT_URL, query=.make_params(params))
   
   djson <- .is_json(durl)
   record <- djson[["data"]][[1]][["downloadOptions"]]
@@ -118,7 +114,7 @@ DOWNLOADOPT_URL <- file.path(URL, "downloadoptions")
   )
   
   # GET works now that the query is used to send params
-  sdata <- httr::GET(SEARCH_URL,
+  sdata <- httr::GET(.EE_API_SEARCH_URL,
                      #verbose(info=TRUE),
                      query=.make_params(params)
   )

--- a/R/ee.R
+++ b/R/ee.R
@@ -103,7 +103,7 @@ DOWNLOADOPT_URL <- file.path(URL, "downloadoptions")
 }
 
 
-.search_ee <- function(token, datasetName, ){
+.search_ee <- function(token, datasetName, ...){
   # Search Earth Explorer for data
   
   # TODO: implement a function to build up the temporal, spatial and other filters to the correct format

--- a/R/ee.R
+++ b/R/ee.R
@@ -52,8 +52,8 @@ DOWNLOADOPT_URL <- file.path(URL, "downloadoptions")
     apiKey = token
   )
   
-  durl <- httr::GET(DOWNLOADOPT_URL, query=.make_params(params)) #Does this work?
-  #durl_post <- httr::POST(downloadopt_url, body=json_params, content_type("application/x-www-form-urlencoded"), verbose(info=TRUE, ssl=TRUE))
+  durl <- httr::GET(DOWNLOADOPT_URL, query=.make_params(params), verbose()) #Does this work?
+  durl_post <- httr::POST(DOWNLOADOPT_URL, body=.make_params(params), content_type("application/x-www-form-urlencoded"), verbose(info=TRUE, ssl=TRUE))
   
   #TODO return the url to the file
   #fileurl <- content(durl)

--- a/R/ee.R
+++ b/R/ee.R
@@ -45,14 +45,18 @@ DOWNLOADOPT_URL <- file.path(url, "downloadoptions")
 }
 
 .get_ee_downurl <- function(datasetName, entityIds, token){
+  # Queries EE for the what the actual download url of a particular file is.
   params <- list(
     datasetName = "ARD_TILE",
     entityIds = "LC08_CU_002008_20190503_20190523_C01_V01",
     apiKey = token
   )
   
-  durl_get <- httr::GET(downloadopt_url, query=.make_params(params)) #Does this work?
+  durl <- httr::GET(downloadopt_url, query=.make_params(params)) #Does this work?
   #durl_post <- httr::POST(downloadopt_url, body=json_params, content_type("application/x-www-form-urlencoded"), verbose(info=TRUE, ssl=TRUE))
+  
+  #TODO return the url to the file
+  #fileurl <- content(durl)
 }
 
 
@@ -66,12 +70,15 @@ DOWNLOADOPT_URL <- file.path(url, "downloadoptions")
   fileurl <- "https://earthexplorer.usgs.gov/download/14320/LC08_CU_002008_20190503_C01_V01/BT/EE"
   #check <- httr::POST(fileurl, body=json_params, content_type("application/x-www-form-urlencoded"), httr::progress())
   # TODO: Set the file name based on the scene name, and the content type in the headers
+  name_file <- "/tmp/LC08api.tar"
   check <- httr::GET(fileurl, 
                      #verbose(info=TRUE),
                      query=.make_params(params), 
                      httr::progress(), 
-                     httr::write_disk("/tmp/LC08api.tar")
+                     httr::write_disk(name_file)
                      )
+  # TODO: verify the size of the file
+  return(name_file)
 }
 
 

--- a/R/ee.R
+++ b/R/ee.R
@@ -48,12 +48,12 @@ DOWNLOADOPT_URL <- file.path(URL, "downloadoptions")
   # Queries EE for the what the actual download url of a particular file is.
   params <- list(
     datasetName = "ARD_TILE",
-    entityIds = "LC08_CU_002008_20190503_20190523_C01_V01",
+    entityIds = "LC08_CU_004010_20140101_C01_V01",
     apiKey = token
   )
   
-  durl <- httr::GET(DOWNLOADOPT_URL, query=.make_params(params), verbose()) #Does this work?
-  durl_post <- httr::POST(DOWNLOADOPT_URL, body=.make_params(params), content_type("application/x-www-form-urlencoded"), verbose(info=TRUE, ssl=TRUE))
+  durl <- httr::GET(DOWNLOADOPT_URL, query=.make_params(params))
+  #durl_post <- httr::POST(DOWNLOADOPT_URL, body=.make_params(params), content_type("application/x-www-form-urlencoded"), verbose(info=TRUE, ssl=TRUE))
   
   #TODO return the url to the file
   #fileurl <- content(durl)
@@ -61,13 +61,13 @@ DOWNLOADOPT_URL <- file.path(URL, "downloadoptions")
 
 
 .download_ee <- function(fileurl, token){
-  # Try downloading a file
+  # Try downloading a file given the downloadOptions$url from get_ee_downurl
   
   params <- list(
     apiKey=token
   )
   
-  fileurl <- "https://earthexplorer.usgs.gov/download/14320/LC08_CU_002008_20190503_C01_V01/BT/EE"
+  #fileurl <- "https://earthexplorer.usgs.gov/download/14320/LC08_CU_002008_20190503_C01_V01/BT/EE"
   #check <- httr::POST(fileurl, body=json_params, content_type("application/x-www-form-urlencoded"), httr::progress())
   # TODO: Set the file name based on the scene name, and the content type in the headers
   name_file <- "/tmp/LC08api.tar"
@@ -82,7 +82,7 @@ DOWNLOADOPT_URL <- file.path(URL, "downloadoptions")
 }
 
 
-.search_ee <- function(token){
+.search_ee <- function(token, datasetName, ){
   # Search Earth Explorer for data
   
   # TODO: implement a function to build up the temporal, spatial and other filters to the correct format
@@ -90,8 +90,8 @@ DOWNLOADOPT_URL <- file.path(URL, "downloadoptions")
     apiKey = token, 
     datasetName = "ARD_TILE",
     temporalFilter = list(
-      startDate= "2006-01-01",
-      endDate= "2006-02-01"
+      startDate= "2014-01-01",
+      endDate= "2014-02-01"
     ),
     maxResults = 5
   )
@@ -105,8 +105,24 @@ DOWNLOADOPT_URL <- file.path(URL, "downloadoptions")
   #sdata <- httr::POST(search_url, body=json_params, content_type("application/x-www-form-urlencoded"), verbose(info=TRUE, ssl=TRUE))
   
   # TODO: check if download is TRUE, otherwise might need to submit an order
+  
+  # TODO: Return the entityID to be passed to downloadoptions
+  djson <- .is_json(sdata)
+  records <- djson[["data"]][["results"]]
+  entities <- sapply(records, function(x){ x[["entityId"]]})
+  
+  return()
 }
 
+.is_json <- function(response){
+  #Check that a response is json and parse it
+  if (httr::http_type(response) == "application/json")  {
+    parsed <- httr::content(sdata, as="parsed")    
+  } else {
+    print("Response was not json")
+    # TODO: handle things like errors.
+  }
+}
 
 
 

--- a/R/ee.R
+++ b/R/ee.R
@@ -1,6 +1,8 @@
 # Functions for getting data from Earth Explorer API
 # Requires machine to machine API approval
 # https://ers.cr.usgs.gov/profile/access
+# Documnentation of API (requires login)
+# https://earthexplorer.usgs.gov/inventory/documentation/json-api
 
 library(httr)
 library(jsonlite)
@@ -62,7 +64,6 @@ DOWNLOADOPT_URL <- file.path(URL, "downloadoptions")
   )
   
   durl <- httr::GET(DOWNLOADOPT_URL, query=.make_params(params))
-  #durl_post <- httr::POST(DOWNLOADOPT_URL, body=.make_params(params), content_type("application/x-www-form-urlencoded"), verbose(info=TRUE, ssl=TRUE))
   
   djson <- .is_json(durl)
   record <- djson[["data"]][[1]][["downloadOptions"]]
@@ -121,8 +122,7 @@ DOWNLOADOPT_URL <- file.path(URL, "downloadoptions")
                      #verbose(info=TRUE),
                      query=.make_params(params)
   )
-  # POST works
-  #sdata <- httr::POST(search_url, body=json_params, content_type("application/x-www-form-urlencoded"), verbose(info=TRUE, ssl=TRUE))
+  
   
   # TODO: check if download is TRUE, otherwise might need to submit an order
   

--- a/R/ee.R
+++ b/R/ee.R
@@ -1,0 +1,105 @@
+# Functions for getting data from Earth Explorer API
+# Requires machine to machine API approval
+# https://ers.cr.usgs.gov/profile/access
+
+library(httr)
+library(jsonlite)
+
+URL <- "https://earthexplorer.usgs.gov/inventory/json/v/1.4.0"
+LOGIN_URL <- file.path(url, "login")
+LOGOUT_URL <- file.path(url, "logout")
+SEARCH_URL <- file.path(url, "search")
+DOWNLOADOPT_URL <- file.path(url, "downloadoptions")
+
+.make_params <- function(params){
+  # EE API requires a very specific format for parameters to the api, 
+  # json inside a query object or body
+  json_params <- paste("jsonRequest=",toJSON(params, auto_unbox = TRUE),sep="")
+  return(json_params)
+}
+
+.login_ee <- function(USERNAME, PASSWORD){
+  # Login and return the apiKey auth token
+  params <- list(
+    username = USERNAME,
+    password = PASSWORD,
+    catalogId = "EE"
+  )
+  auth <- httr::POST(login_url, body=.make_params(params), content_type("application/x-www-form-urlencoded"))
+  
+  #TODO: Check the http status
+  token <- content(auth)$data  
+  return(token)
+}
+
+.logout_ee <- function(token){
+  # Logout
+
+  params <- list(
+    apiKey=token
+  )
+  
+  logout <- httr::GET(logout_url, query=.make_params(params))
+  #TODO: Check the http status
+  # TODO: If error api_version is 1.3.0, if works 1.4.0
+}
+
+.get_ee_downurl <- function(datasetName, entityIds, token){
+  params <- list(
+    datasetName = "ARD_TILE",
+    entityIds = "LC08_CU_002008_20190503_20190523_C01_V01",
+    apiKey = token
+  )
+  
+  durl_get <- httr::GET(downloadopt_url, query=.make_params(params)) #Does this work?
+  #durl_post <- httr::POST(downloadopt_url, body=json_params, content_type("application/x-www-form-urlencoded"), verbose(info=TRUE, ssl=TRUE))
+}
+
+
+.download_ee <- function(fileurl, token){
+  # Try downloading a file
+  
+  params <- list(
+    apiKey=token
+  )
+  
+  fileurl <- "https://earthexplorer.usgs.gov/download/14320/LC08_CU_002008_20190503_C01_V01/BT/EE"
+  #check <- httr::POST(fileurl, body=json_params, content_type("application/x-www-form-urlencoded"), httr::progress())
+  # TODO: Set the file name based on the scene name, and the content type in the headers
+  check <- httr::GET(fileurl, 
+                     #verbose(info=TRUE),
+                     query=.make_params(params), 
+                     httr::progress(), 
+                     httr::write_disk("/tmp/LC08api.tar")
+                     )
+}
+
+
+.search_ee <- function(token){
+  # Search Earth Explorer for data
+  
+  # TODO: implement a function to build up the temporal, spatial and other filters to the correct format
+  params <- list(
+    apiKey = token, 
+    datasetName = "ARD_TILE",
+    temporalFilter = list(
+      startDate= "2006-01-01",
+      endDate= "2006-02-01"
+    ),
+    maxResults = 5
+  )
+  
+  # GET works now that the query is used to send params
+  sdata <- httr::GET(search_url,
+                     #verbose(info=TRUE),
+                     query=.make_params(params)
+  )
+  # POST works
+  #sdata <- httr::POST(search_url, body=json_params, content_type("application/x-www-form-urlencoded"), verbose(info=TRUE, ssl=TRUE))
+  
+  # TODO: check if download is TRUE, otherwise might need to submit an order
+}
+
+
+
+

--- a/R/ers.R
+++ b/R/ers.R
@@ -1,9 +1,9 @@
 library(httr)
 library(xml2)
 
-LOGIN_URL <- "https://ers.cr.usgs.gov/login"
+LOGIN_URL <- "https://ers.cr.usgs.gov"
 LOGOUT_URL <- "https://ers.cr.usgs.gov/logout"
-HANDLE <- "https://usgs.gov"
+HANDLE <- httr::handle("https://usgs.gov")
 
 .verify <- function(response){
   # Verify a response by saving the html so a person can look at it
@@ -13,7 +13,9 @@ HANDLE <- "https://usgs.gov"
 
 find_token <- function(){
   # Scrape a csrf token from the login page to allow login
-  response <- httr::GET(LOGIN_URL, verbose())
+  
+  #TODO: not reuse an existing session, since we need a fresh csrf token
+  response <- httr::GET("https://ers.cr.usgs.gov", verbose(), config(forbid_reuse = 1))
 
   if (response$status_code == 200){
     # Search the response content for the csrf
@@ -31,18 +33,20 @@ find_token <- function(){
 
 login_ers <- function(user, passw, csrf){
   # Login to USGS ERS system and return an authentication cookie
+  csrf <- find_token()
+  
   params <- list(
     username = user,
     password = passw,
-    csrf_token = find_token()
+    csrf_token = csrf
   )
   response <- httr::POST(LOGIN_URL, body=params, encode="form", verbose(info=TRUE, ssl=TRUE), handle = HANDLE)
-
+  #response <- httr::POST(LOGIN_URL, body=params, handle = HANDLE, verbose(info=TRUE, ssl=TRUE))
 }
 
 logout_ers <- function(){
   # Logout function
-  response <- httr::GET(LOGIN_URL, verbose(), handle = HANDLE)
+  response <- httr::GET(LOGOUT_URL, verbose(), handle = HANDLE)
 }
 
 find_url <- function(scene){
@@ -51,7 +55,7 @@ find_url <- function(scene){
 
 get_files <- function(scene_url){
   # Download a scene from Earth Explorer
-  # How to reuse the session cookie?
+  # How to reuse the session cookie? set a handle?
   scene_url <- "https://earthexplorer.usgs.gov/download/14320/LC08_CU_002008_20190503_C01_V01/BT/EE"
   response <- httr::GET(scene_url, httr::progress(), httr::write_disk("/tmp/LC08api2.tar"), verbose(), handle = HANDLE)
   

--- a/R/ers.R
+++ b/R/ers.R
@@ -4,7 +4,7 @@
 .ERS_LOGIN_URL <- file.path(.ERS_MAIN_URL, "login/")
 .ERS_LOGOUT_URL <- file.path(.ERS_MAIN_URL, "logout")
 .ERS_DOMAIN <- "https://usgs.gov"
-.HANDLE <- httr::handle(.ERS_DOMAIN)
+.ERS_HANDLE <- httr::handle(.ERS_DOMAIN)
 
 .verify <- function(response){
   # Verify a response by saving the html so a person can look at it
@@ -23,9 +23,9 @@
 
   if (response$status_code == 200){
     # Search the response content for the csrf
-    contents <- xml2::read_html(content(response, as = "text"))
+    contents <- xml2::read_html(httr::content(response, as = "text"))
     inputs <- xml2::xml_find_all(contents, "//input")
-    csrf <- xml_attr(inputs[grep("csrf_token", inputs)], "value")
+    csrf <- xml2::xml_attr(inputs[grep("csrf_token", inputs)], "value")
     return(csrf)
     
   } else {
@@ -66,7 +66,7 @@
 
 .logout_ers <- function(){
   # Logout function
-  response <- httr::GET(.LOGOUT_URL, handle = .ERS_HANDLE)
+  response <- httr::GET(.ERS_LOGOUT_URL, handle = .ERS_HANDLE)
   httr::handle_reset(.ERS_DOMAIN)
   return(response)
 }

--- a/R/ers.R
+++ b/R/ers.R
@@ -5,14 +5,14 @@ LOGIN_URL <- "https://ers.cr.usgs.gov/login"
 
 find_token <- function(){
   # Scrape a csrf token from the login page to allow login
-  response <- httr::GET(LOGIN_URL)
+  response <- httr::GET(LOGIN_URL, verbose())
 
   if (response$status_code == 200){
     # Search the response content for the csrf
     contents <- content(response, as = "parsed", type = "text/html")
     inputs <- xml2::xml_find_all(contents, "//input")
-    token <- xml_attr(inputs[grep("csrf_token", inputs)], "value")
-    return(token)
+    csrf <- xml_attr(inputs[grep("csrf_token", inputs)], "value")
+    return(csrf)
     
   } else {
     print("Web Page not working try again later")
@@ -21,22 +21,27 @@ find_token <- function(){
 
 }
 
-login_ers <- function(user, passw, token){
+login_ers <- function(user, passw, csrf){
   # Login to USGS ERS system and return an authentication cookie
   params <- list(
     username = user,
     password = passw,
-    csrf_token = token
+    csrf_token = find_token()
   )
-  #reponse <- httr::POST(LOGIN_URL, data=params, verbose())
-  reponse <- httr::POST(LOGIN_URL, data=params, verbose())
+  response <- httr::POST(LOGIN_URL, body=params, encode="form", verbose(info=TRUE, ssl=TRUE))
+  
+  # Verify
+  #xml2::write_html( content(response, as="parsed"), "local_test/check.html")
   
 }
 
-find_url <- function(){
+find_url <- function(scene){
   # Scrape the Download URL for the actual urls to files
 }
 
-get_files <- function(){
+get_files <- function(scene_url){
   # Download a scene from Earth Explorer
+  scene_url <- "https://earthexplorer.usgs.gov/download/14320/LC08_CU_002008_20190503_C01_V01/BT/EE"
+  response <- httr::GET(scene_url, httr::progress(), httr::write_disk("/tmp/LC08api.tar"))
+  
 }

--- a/R/ers.R
+++ b/R/ers.R
@@ -92,7 +92,7 @@ find_durls_ers <- function(scene_browse){
   #scene_url <- "https://earthexplorer.usgs.gov/download/14320/LC08_CU_002008_20190503_C01_V01/BT/EE"
   
   tmp <- tempfile()
-
+  
   response <- httr::GET(scene_url, httr::progress(), httr::write_disk(tmp), handle = .ERS_HANDLE)
   
   # Get the file type, size, and name from the header
@@ -110,7 +110,7 @@ find_durls_ers <- function(scene_browse){
   return(final_path)
 }
 
-download_ers <- function(scenes){
+download_ers <- function(scenes, path, overwrite, ...){
   # Should credentials be passed in?
   cred <- getCredentials(url=.ERS_MAIN_URL)
   
@@ -120,8 +120,10 @@ download_ers <- function(scenes){
   # login an get a session
   .login_ers(user=cred$user, passw=cred$password)
   
+  # TODO: Wrap in a Try to catch errors from downloads
   outfiles <- lapply(durls, .get_files_ers)
   
+  # logout of the session
   .logout_ers()
   
   return(outfiles)

--- a/R/ers.R
+++ b/R/ers.R
@@ -3,11 +3,11 @@
 library(httr)
 library(xml2)
 
-MAIN_URL <- "https://ers.cr.usgs.gov"
-LOGIN_URL <- file.path(MAIN_URL, "login/")
-LOGOUT_URL <- file.path(MAIN_URL, "logout")
-DOMAIN <- "https://usgs.gov"
-HANDLE <- httr::handle(DOMAIN)
+ERS_MAIN_URL <- "https://ers.cr.usgs.gov"
+ERS_LOGIN_URL <- file.path(ERS_MAIN_URL, "login/")
+ERS_LOGOUT_URL <- file.path(ERS_MAIN_URL, "logout")
+ERS_DOMAIN <- "https://usgs.gov"
+HANDLE <- httr::handle(ERS_DOMAIN)
 
 .verify <- function(response){
   # Verify a response by saving the html so a person can look at it
@@ -20,9 +20,9 @@ HANDLE <- httr::handle(DOMAIN)
   # Scrape a csrf token from the login page to allow login
   
   # We reset the cookies every time we login, to make sure we get a fresh session.
-  handle_reset(DOMAIN)
+  handle_reset(ERS_DOMAIN)
   
-  response <- httr::GET("https://ers.cr.usgs.gov/", handle=HANDLE)
+  response <- httr::GET("https://ers.cr.usgs.gov/", handle=ERS_HANDLE)
 
   if (response$status_code == 200){
     # Search the response content for the csrf
@@ -48,7 +48,7 @@ HANDLE <- httr::handle(DOMAIN)
     password = passw
   )
   
-  response <- httr::POST(LOGIN_URL, body=params, encode="form", handle = HANDLE)
+  response <- httr::POST(LOGIN_URL, body=params, encode="form", handle = ERS_HANDLE)
   
   if (response$status_code == 200){
     html <- content(response, as="text")
@@ -69,7 +69,9 @@ HANDLE <- httr::handle(DOMAIN)
 
 .logout_ers <- function(){
   # Logout function
-  response <- httr::GET(LOGOUT_URL, handle = HANDLE)
+  response <- httr::GET(LOGOUT_URL, handle = ERS_HANDLE)
+  handle_reset(ERS_DOMAIN)
+  return(response)
 }
 
 find_durls_ers <- function(scene_browse){
@@ -94,7 +96,7 @@ find_durls_ers <- function(scene_browse){
   
   tmp <- tempfile()
 
-  response <- httr::GET(scene_url, httr::progress(), httr::write_disk(tmp), handle = HANDLE)
+  response <- httr::GET(scene_url, httr::progress(), httr::write_disk(tmp), handle = ERS_HANDLE)
   
   # Get the file type, size, and name from the header
   filename <- unlist(strsplit(httr::headers(response)$`content-disposition`, "="))[2]
@@ -113,7 +115,7 @@ find_durls_ers <- function(scene_browse){
 
 download_ers <- function(scenes){
   # Should credentials be passed in?
-  cred <- getCredentials(url=MAIN_URL, ...)
+  cred <- getCredentials(url=ERS_MAIN_URL, ...)
   
   # find the urls without auth, based on the known scene urls
   durls <- lapply(scenes, find_durls_ers)

--- a/R/ers.R
+++ b/R/ers.R
@@ -2,6 +2,14 @@ library(httr)
 library(xml2)
 
 LOGIN_URL <- "https://ers.cr.usgs.gov/login"
+LOGOUT_URL <- "https://ers.cr.usgs.gov/logout"
+HANDLE <- "https://usgs.gov"
+
+.verify <- function(response){
+  # Verify a response by saving the html so a person can look at it
+  xml2::write_html( content(response, as="parsed"), "local_test/check.html")
+  browseURL("local_test/check.html")
+}
 
 find_token <- function(){
   # Scrape a csrf token from the login page to allow login
@@ -28,11 +36,13 @@ login_ers <- function(user, passw, csrf){
     password = passw,
     csrf_token = find_token()
   )
-  response <- httr::POST(LOGIN_URL, body=params, encode="form", verbose(info=TRUE, ssl=TRUE))
-  
-  # Verify
-  #xml2::write_html( content(response, as="parsed"), "local_test/check.html")
-  
+  response <- httr::POST(LOGIN_URL, body=params, encode="form", verbose(info=TRUE, ssl=TRUE), handle = HANDLE)
+
+}
+
+logout_ers <- function(){
+  # Logout function
+  response <- httr::GET(LOGIN_URL, verbose(), handle = HANDLE)
 }
 
 find_url <- function(scene){
@@ -41,7 +51,8 @@ find_url <- function(scene){
 
 get_files <- function(scene_url){
   # Download a scene from Earth Explorer
+  # How to reuse the session cookie?
   scene_url <- "https://earthexplorer.usgs.gov/download/14320/LC08_CU_002008_20190503_C01_V01/BT/EE"
-  response <- httr::GET(scene_url, httr::progress(), httr::write_disk("/tmp/LC08api.tar"))
+  response <- httr::GET(scene_url, httr::progress(), httr::write_disk("/tmp/LC08api2.tar"), verbose(), handle = HANDLE)
   
 }

--- a/R/ers.R
+++ b/R/ers.R
@@ -11,16 +11,17 @@ HANDLE <- httr::handle(DOMAIN)
 
 .verify <- function(response){
   # Verify a response by saving the html so a person can look at it
-  xml2::write_html( content(response, as="parsed"), "local_test/check.html")
-  browseURL("local_test/check.html")
+  tmp_html <- "tmp/check.html" 
+  xml2::write_html( content(response, as="parsed"), tmp_html)
+  browseURL(tmp_html)
 }
 
-find_token <- function(){
+.find_token <- function(){
   # Scrape a csrf token from the login page to allow login
   
+  # We reset the cookies every time we login, to make sure we get a fresh session.
   handle_reset(DOMAIN)
   
-  #TODO: not reuse an existing session, since we need a fresh csrf token
   response <- httr::GET("https://ers.cr.usgs.gov/", verbose(), handle=HANDLE)
 
   if (response$status_code == 200){
@@ -37,7 +38,7 @@ find_token <- function(){
 
 }
 
-login_ers <- function(user, passw, csrf){
+.login_ers <- function(user, passw, csrf){
   # Login to USGS ERS system and return an authentication cookie
   csrf <- find_token()
   
@@ -47,8 +48,7 @@ login_ers <- function(user, passw, csrf){
     password = passw
   )
   
-  response <- httr::POST(LOGIN_URL, body=params, encode="form", verbose(info=TRUE, ssl=TRUE), handle = HANDLE)
-  #response <- httr::POST(LOGIN_URL, body=params, handle = HANDLE, verbose(info=TRUE, ssl=TRUE))
+  response <- httr::POST(LOGIN_URL, body=params, encode="form", handle = HANDLE)
   
   if (response$status_code == 200){
     html <- content(response, as="text")
@@ -65,25 +65,39 @@ login_ers <- function(user, passw, csrf){
     return(FALSE)
   }
   
-
 }
 
-logout_ers <- function(){
+.logout_ers <- function(){
   # Logout function
   response <- httr::GET(LOGOUT_URL, verbose(), handle = HANDLE)
 }
 
-find_url <- function(scene){
+find_durls <- function(scene_browse){
   # Scrape the Download URL for the actual urls to files
-  # May not require login
-  list_url <- "https://earthexplorer.usgs.gov/download/external/options/LANDSAT_8_C1/LC81710582019149LGN00/INVSVC/"
-  
+  # TODO: How do we want to take in the items that need to found, results of CMR or EE search 
+  #list_url <- "https://earthexplorer.usgs.gov/download/external/options/LANDSAT_8_C1/LC81710582019149LGN00/INVSVC/"
+  response <- httr::GET(scene_browse)
+  if (response$status_code == 200){
+    # Search the response content for the csrf
+    contents <- content(response, as = "parsed", type = "text/html")
+    inputs <- xml2::xml_find_all(contents, "//div[@id='optionsPage']/div/div")
+    onclicks <- xml_attr(inputs, "onclick")
+    durls <- gsub("'","",sapply(strsplit(onclicks, "="), `[`, 2))
+    # Usually there is more than 1 file, the user needs to decide which files they want
+    return(durls)
+  }
 }
 
 get_files <- function(scene_url){
   # Download a scene from Earth Explorer
-  # How to reuse the session cookie? set a handle?
-  scene_url <- "https://earthexplorer.usgs.gov/download/14320/LC08_CU_002008_20190503_C01_V01/BT/EE"
-  response <- httr::GET(scene_url, httr::progress(), httr::write_disk("/tmp/LC08api2.tar"), verbose(), handle = HANDLE)
+  # TODO: Download to tmp directory, rename file to correct name upon moving to final location
+  # TODO: get the file type and size from the header
+  #scene_url <- "https://earthexplorer.usgs.gov/download/14320/LC08_CU_002008_20190503_C01_V01/BT/EE"
+  response <- httr::GET(scene_url, httr::progress(), httr::write_disk("/tmp/LC08api2-2.tar"), handle = HANDLE)
   
+  size_check <- httr::headers(response)$`content-length`
+  content_check <- httr::http_type(response) #Note a zip from USGS could mean a .tar or tar.gz
+  
+  # TODO: return the path to the actual files final location
+  return(TRUE)
 }

--- a/R/ers.R
+++ b/R/ers.R
@@ -1,0 +1,42 @@
+library(httr)
+library(xml2)
+
+LOGIN_URL <- "https://ers.cr.usgs.gov/login"
+
+find_token <- function(){
+  # Scrape a csrf token from the login page to allow login
+  response <- httr::GET(LOGIN_URL)
+
+  if (response$status_code == 200){
+    # Search the response content for the csrf
+    contents <- content(response, as = "parsed", type = "text/html")
+    inputs <- xml2::xml_find_all(contents, "//input")
+    token <- xml_attr(inputs[grep("csrf_token", inputs)], "value")
+    return(token)
+    
+  } else {
+    print("Web Page not working try again later")
+    return(NULL)
+  }
+
+}
+
+login_ers <- function(user, passw, token){
+  # Login to USGS ERS system and return an authentication cookie
+  params <- list(
+    username = user,
+    password = passw,
+    csrf_token = token
+  )
+  #reponse <- httr::POST(LOGIN_URL, data=params, verbose())
+  reponse <- httr::POST(LOGIN_URL, data=params, verbose())
+  
+}
+
+find_url <- function(){
+  # Scrape the Download URL for the actual urls to files
+}
+
+get_files <- function(){
+  # Download a scene from Earth Explorer
+}

--- a/R/ers.R
+++ b/R/ers.R
@@ -1,5 +1,6 @@
 # Functions for gettings data from Earth Explorer with regular login
 
+# TODO: Move these globals into a package env
 .ERS_MAIN_URL <- "https://ers.cr.usgs.gov"
 .ERS_LOGIN_URL <- file.path(.ERS_MAIN_URL, "login/")
 .ERS_LOGOUT_URL <- file.path(.ERS_MAIN_URL, "logout")
@@ -87,7 +88,7 @@ find_durls_ers <- function(scene_browse){
   }
 }
 
-.get_files_ers <- function(scene_url, ...){
+.get_files_ers <- function(scene_url, path="", ...){
   # Download a scene from Earth Explorer, must call .login_ers before using
   #scene_url <- "https://earthexplorer.usgs.gov/download/14320/LC08_CU_002008_20190503_C01_V01/BT/EE"
   
@@ -102,7 +103,7 @@ find_durls_ers <- function(scene_browse){
   # TODO: check the size and content
   
   fullpath <- "/tmp" # The outpu directory, should come from user.
-  final_path <- file.path(fullpath, filename)
+  final_path <- file.path(path, filename)
   
   # Download to tmp directory, rename file to correct name upon moving to final location
   file.rename(tmp, final_path )
@@ -111,11 +112,12 @@ find_durls_ers <- function(scene_browse){
 }
 
 download_ers <- function(scenes, path, overwrite, ...){
-  # Should credentials be passed in?
-  cred <- getCredentials(url=.ERS_MAIN_URL)
+  # Downloads the files from ERS using basic account login
   
-  # find the urls without auth, based on the known scene urls
-  durls <- lapply(scenes, find_durls_ers)
+  # Make sure to get the urls with the find_durls_ers function
+  
+  # Should credentials be passed in?
+  cred <- getCredentials(url=.ERS_MAIN_URL, path)
   
   # login an get a session
   .login_ers(user=cred$user, passw=cred$password)

--- a/R/ers.R
+++ b/R/ers.R
@@ -1,3 +1,5 @@
+# Functions for gettings data from Earth Explorer with regular login
+
 library(httr)
 library(xml2)
 

--- a/R/getLandsat.R
+++ b/R/getLandsat.R
@@ -40,17 +40,25 @@ getLandsat <- function(product="Landsat_8_OLI_TIRS_C1", start_date, end_date, ao
 	
 	# Select out the urls and remove duplicates
 	# TODO: Pass server through to indicate AWS, GCP or USGS - only does AWS now.
+	# TODO: For ERS results hit the find_durls_ers to get the actual file urls
 	fileurls <- simplify_urls(results, sat="L8")
 
 	
   # TODO: need a better try-error message for the function
 	if (length(fileurls) > 0) {
 		if (download){
-			cred <- getCredentials(url="https://urs.earthdata.nasa.gov/users/new", ...)
-			files <- cmr_download(urls = fileurls, path = path, 
-					 username = cred$user, password = cred$password,
-					 overwrite = overwrite)			
-			# rh: is there a better way? 
+		  # rh: is there a better way? 
+		  if(server=="AWS"){
+		    files <- cmr_download(urls = fileurls, path = path,
+		                          overwrite = overwrite
+		                          )			
+		  } else if (server=="ERS"){
+		    files <- download_ers(scenes = fileurls, path = path, 
+		                          overwrite = overwrite
+		                          )
+			}
+			
+		  # TODO: This is going to return junk names for things from ERS 
 			ff <- file.path(path, basename(fileurls))	
 			return(ff)		 
 		} else {

--- a/R/getLandsat.R
+++ b/R/getLandsat.R
@@ -40,9 +40,10 @@ getLandsat <- function(product="Landsat_8_OLI_TIRS_C1", start_date, end_date, ao
 	
 	# Select out the urls and remove duplicates
 	# TODO: Pass server through to indicate AWS, GCP or USGS - only does AWS now.
-	# TODO: For ERS results hit the find_durls_ers to get the actual file urls
-	fileurls <- simplify_urls(results, sat="L8")
+	fileurls <- simplify_urls(results, server)
 
+	# TODO: Apply filters if you only want to get certain files from the results
+	# Example: only download TOA or SR, or L1
 	
   # TODO: need a better try-error message for the function
 	if (length(fileurls) > 0) {

--- a/R/getLandsat.R
+++ b/R/getLandsat.R
@@ -13,8 +13,8 @@ getLandsat <- function(product="Landsat_8_OLI_TIRS_C1", start_date, end_date, ao
   # TODO: Implement alternate download from Google or EROS USGS for 4,5,7
   # Takes argument about which bands to download, will vary by Landsat version.
   
-	stopifnot(require(readr))
-	stopifnot(require(httr))
+	#stopifnot(require(readr))
+	#stopifnot(require(httr))
 	
 	if(missing(product)) stop("provide a product name")
 	if(missing(start_date)) stop("provide a start_date")

--- a/R/getMODIS.R
+++ b/R/getMODIS.R
@@ -34,7 +34,7 @@ getModis <- function(product, start_date, end_date, aoi, download=FALSE, path=""
 	results <- searchGranules(product = product, start_date = start_date, end_date = end_date, extent = aoi, limit = limit)
 	
 	# Select out the urls and remove duplicates
-	fileurls <- simplify_urls(results, sat="MODIS")
+	fileurls <- simplify_urls(results, server="MODIS")
 	
   # TODO: need a better try-error message for the function
 	if (length(fileurls) > 0) {

--- a/R/getMODIS.R
+++ b/R/getMODIS.R
@@ -8,8 +8,8 @@
 getModis <- function(product, start_date, end_date, aoi, download=FALSE, path="",
                      version = "006", limit = 100000, server = "LPDAAC_ECS", overwrite=FALSE, ...) {
   
-	stopifnot(require(readr))
-	stopifnot(require(httr))
+	#stopifnot(require(readr))
+	#stopifnot(require(httr))
 	
 	if(missing(product)) stop("provide a product name")
 	if(missing(start_date)) stop("provide a start_date")

--- a/man/getLandsat.Rd
+++ b/man/getLandsat.Rd
@@ -16,13 +16,13 @@ getModis(product, start_date, end_date, aoi, download = FALSE, path, version="00
 \arguments{
   \item{product}{character. Supported products can be found using \code{\link{getProducts}}, currently limited to Landsat_8_OLI_TIRS_C1}
   \item{start_date}{character. Start date for the data requested formatted yyyy-m-d}
-  \item{end_date}{Character. end date for the data requested formatted yyyy-m-d}
+  \item{end_date}{character. end date for the data requested formatted yyyy-m-d}
   \item{aoi}{numeric vector of four elements (minimum longitude, maximum longitude, minimum latitude, maximum latitude) encompassing the area of interest. Or a SpatExtent or Extent object, or any object from which an Extent can be extracted (see examples)}
   \item{download}{logical. If \code{TRUE} data will be downloaded unless it is present in the download directory}
   \item{path}{character. Path name indicating where to store the data}
   \item{version}{character}
   \item{limit}{integer > 0}
-  \item{server}{character}
+  \item{server}{character. Defaults to AWS (Landsat 8 only). See Details}
   \item{...}{Additional arguments. These can be product specific. See Details)}
 }
 
@@ -33,6 +33,9 @@ character vector of file names pointing to the downloaded files (if \code{downlo
 
 \details{
 If no data is available between \code{start_date} and \code{end_date}, files for the closest dates are returned. 
+
+Server: AWS, ERS
+
 }
 
 \seealso{ \code{\link[luna]{getProducts}}}
@@ -46,5 +49,13 @@ dir <- tempdir()
 f <- getLandsat(product = product,
             start_date = sdate, end_date = edate,
             aoi = area, download = FALSE, path=dir)
+            
+# An example of ARD Tiles from ERS server
+product <- "Landsat4-8_ARD_US_C1"
+area <- c(-122.422996520996, -121.501968383789, 38.3139801025391, 38.9253616333008)
+f1 <- getLandsat(product = product,
+            start_date = sdate, end_date = edate,
+            aoi = area, download = FALSE, path=dir, 
+            server="ERS")
 }
 


### PR DESCRIPTION
Implements ERS and EarthExplorer (EE) api for downloading any USGS served data. Specifically implements Landsat currently. EE requires an API key to be approved before use.

TODO: As discussed we should probably move the global variables at the top to ee.R and ers.R into a package based environment.