### PR TITLE
bug fix in .cmr_download

### DIFF
--- a/R/cmr.R
+++ b/R/cmr.R
@@ -116,7 +116,7 @@
 	
 	for (i in 1:length(urls)) {
 		f <- tryCatch(
-				.cmr_download_one(urls[i], path, username, password, overwrite, cookie_file, ...), 
+				.cmr_download_one(urls[i], path, username, password, overwrite, cookie_file), 
 				error = function(e){e}
 			)
 		if (inherits(f, "error")) {


### PR DESCRIPTION
get_NASA was producing warnings without downloading requested files. I removed the ellipses in .cmr_download, which seems to have fixed the problem.